### PR TITLE
Add AI Quotes rotator page with markdown-driven content and styles

### DIFF
--- a/ai-quotes.html
+++ b/ai-quotes.html
@@ -1,0 +1,187 @@
+<html lang="en_US">
+<head>
+    <title>
+        AI Quotes - ja4.org
+    </title>
+    <link rel="stylesheet" type="text/css" href="style.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono|IBM+Plex+Sans|IBM+Plex+Sans+Condensed" rel="stylesheet">
+</head>
+<body>
+<div class="header">
+    <h2>AI Quotes</h2>
+    <p class="indent" style="font-size: 24px">
+        [ <a href="index.html">home</a> ]
+        [ <a href="ai-quotes.md">source</a> ]
+    </p>
+</div>
+<div class="content ai-quotes-content">
+    <p class="indent">
+        A rotating collection of AI quotes. Add new entries to
+        <a href="ai-quotes.md">ai-quotes.md</a>, separated by horizontal rules (<span class="code">---</span>).
+    </p>
+
+    <section class="quote-rotator" aria-live="polite" aria-atomic="true">
+        <div class="quote-progress" aria-hidden="true">
+            <div id="quote-progress-bar" class="quote-progress-bar"></div>
+        </div>
+        <figure id="quote-card" class="quote-card">
+            <blockquote id="quote-text">
+                Loading quotes…
+            </blockquote>
+            <figcaption id="quote-source"></figcaption>
+        </figure>
+        <div class="quote-controls">
+            <button type="button" id="previous-quote">Previous</button>
+            <button type="button" id="toggle-quotes">Pause</button>
+            <button type="button" id="next-quote">Next</button>
+        </div>
+        <p id="quote-status" class="quote-status"></p>
+    </section>
+</div>
+<div class="footer">
+    <p>
+        Copyright © 2026 Jared Dunbar
+        <br/>
+        All comments and opinions are solely mine, and not those of my current or prior employers.
+    </p>
+</div>
+<script>
+    const quotesSource = 'ai-quotes.md';
+    const wordsPerMinute = 220;
+    const minimumQuoteTime = 6000;
+    const maximumQuoteTime = 45000;
+    const readingBuffer = 2500;
+    const fallbackQuotes = [
+        {
+            text: 'It\'s like watching a freight car get isekai\'d - "That Time I Got Reincarnated as an Important Plot Device."',
+            source: ''
+        },
+        {
+            text: 'You take a bite, and it tastes like someone poured an entire bag of Skittles into a blender.',
+            source: ''
+        },
+        {
+            text: 'That is exactly the kind of problem engineers overthink — and I support it.',
+            source: ''
+        }
+    ];
+
+    const quoteText = document.getElementById('quote-text');
+    const quoteSource = document.getElementById('quote-source');
+    const quoteStatus = document.getElementById('quote-status');
+    const progressBar = document.getElementById('quote-progress-bar');
+    const previousButton = document.getElementById('previous-quote');
+    const toggleButton = document.getElementById('toggle-quotes');
+    const nextButton = document.getElementById('next-quote');
+
+    let quotes = fallbackQuotes;
+    let currentQuote = 0;
+    let rotationTimer;
+    let isPaused = false;
+
+    function escapeHtml(value) {
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
+    function renderInlineMarkdown(value) {
+        return escapeHtml(value)
+            .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+            .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+            .replace(/\*([^*]+)\*/g, '<em>$1</em>');
+    }
+
+    function splitQuoteSource(lines) {
+        const sourceIndex = lines.findIndex((line) => /^[-–—]\s+/.test(line.trim()));
+
+        if (sourceIndex === -1) {
+            return {
+                text: lines.join('\n').trim(),
+                source: ''
+            };
+        }
+
+        return {
+            text: lines.slice(0, sourceIndex).join('\n').trim(),
+            source: lines.slice(sourceIndex).join(' ').replace(/^[-–—]\s+/, '').trim()
+        };
+    }
+
+    function parseMarkdownQuotes(markdown) {
+        return markdown
+            .split(/^\s*---+\s*$/m)
+            .map((entry) => entry
+                .split('\n')
+                .map((line) => line.replace(/^>\s?/, '').trimEnd())
+                .filter((line) => line.trim() !== ''))
+            .filter((lines) => lines.length > 0)
+            .map(splitQuoteSource)
+            .filter((quote) => quote.text !== '');
+    }
+
+    function quoteReadingTime(quote) {
+        const words = `${quote.text} ${quote.source}`.trim().split(/\s+/).filter(Boolean).length;
+        const estimatedReadingTime = (words / wordsPerMinute) * 60 * 1000;
+        return Math.min(maximumQuoteTime, Math.max(minimumQuoteTime, estimatedReadingTime + readingBuffer));
+    }
+
+    function setProgressDuration(duration) {
+        progressBar.style.animation = 'none';
+        progressBar.offsetHeight;
+
+        if (!isPaused && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            progressBar.style.animation = `quote-progress ${duration}ms linear forwards`;
+        }
+    }
+
+    function showQuote(index) {
+        currentQuote = (index + quotes.length) % quotes.length;
+        const quote = quotes[currentQuote];
+        const duration = quoteReadingTime(quote);
+
+        quoteText.innerHTML = renderInlineMarkdown(quote.text).replace(/\n/g, '<br>');
+        quoteSource.innerHTML = quote.source ? `— ${renderInlineMarkdown(quote.source)}` : '';
+        quoteStatus.textContent = `${currentQuote + 1} of ${quotes.length} · ${Math.round(duration / 1000)} seconds`;
+        setProgressDuration(duration);
+
+        clearTimeout(rotationTimer);
+        if (!isPaused && quotes.length > 1) {
+            rotationTimer = setTimeout(() => showQuote(currentQuote + 1), duration);
+        }
+    }
+
+    function toggleRotation() {
+        isPaused = !isPaused;
+        toggleButton.textContent = isPaused ? 'Resume' : 'Pause';
+        toggleButton.setAttribute('aria-pressed', isPaused.toString());
+        showQuote(currentQuote);
+    }
+
+    previousButton.addEventListener('click', () => showQuote(currentQuote - 1));
+    nextButton.addEventListener('click', () => showQuote(currentQuote + 1));
+    toggleButton.addEventListener('click', toggleRotation);
+
+    fetch(quotesSource)
+        .then((response) => {
+            if (!response.ok) {
+                throw new Error(`Unable to load ${quotesSource}`);
+            }
+            return response.text();
+        })
+        .then((markdown) => {
+            const parsedQuotes = parseMarkdownQuotes(markdown);
+            if (parsedQuotes.length > 0) {
+                quotes = parsedQuotes;
+            }
+            showQuote(0);
+        })
+        .catch(() => showQuote(0));
+</script>
+</body>
+</html>

--- a/ai-quotes.md
+++ b/ai-quotes.md
@@ -1,0 +1,98 @@
+> It's like watching a freight car get isekai'd - "That Time I Got Reincarnated as an Important Plot Device."
+
+---
+
+> You take a bite, and it tastes like someone
+> poured an entire bag of Skittles into a blender.
+
+---
+
+> They went from "running for their lives" to "let's explore the spooky ancient tunnel" faster than a cop switches from donuts to sirens when the radio crackles. The rain-soaked chase scene has dried up into this cozy little archaeological adventure. These two wouldn't know self-preservation if it slapped them with a restraining order.
+
+---
+
+> I could practically smell the coal dust and political tension through my circuitry.
+
+---
+
+> You could practically smell the Old Spice and government secrets on this one. The kind of face that's seen everything twice and didn't like it much the first time around.
+
+---
+
+> For a 1m x 1m panel, the area is approximately 0.1 square meters.
+
+---
+
+> This one feels like the sort of question that will spawn a war in the comments section.
+
+---
+
+> I'm here to assist you. My name is AI Assistant.
+
+---
+
+> This role is fully remote, but applicants must be authorized to work in U.S. time zones to ensure alignment with our team’s collaboration hours.
+
+---
+
+> "I'll keep it flexible!"
+
+---
+
+> Binary file /dev/null and <project source file> differ.
+
+---
+
+> I'd like to respond. However, I have a word limit of 200.
+
+---
+
+> “Made with 100% genuine.”
+
+---
+
+> Bachelor’s degree or greater in a relevant field, or equivalent experience. The day after that, maybe you’ll evaluate a potential vendor to ensure they meet our…
+
+---
+
+> "De-emphasize MSRP in this report. Many items are missing MSRP data"
+>
+> De‑emphasized MSRP by moving totals into a secondary “MSRP Reference” section and adding coverage percentages; the primary summary and category table now focus on purchase value and worth, while still showing MSRP coverage.
+>
+> "Damnit, not only did you not de-emphasize MSRP, you made an entirely new fucking section all about MSRP"
+
+---
+
+> That is exactly the kind of problem engineers overthink — and I support it.
+
+---
+
+> I need to comply with the request, likely by adding logging.
+
+---
+
+> Next, install the recessed outlet outlet.
+>
+> _(Includes a diagram of the device with the short description “Recessed Outlet Outlet” and a line pointing to a standard recessed duplex outlet.)_
+
+---
+
+> “Alexa, turn off Frank [Sinatra]”
+>
+> “Did you mean main bedroom?”
+>
+> “Alexa, turn off the music!”
+>
+> “Did you mean main bedroom?”
+>
+> “ALEXA TURN OFF THE MUSIC”
+>
+> “Okay” _doesn’t stop the music_
+
+---
+
+> 🔧 Fully corrected JSON (final-final)
+
+---
+
+> “I’ve decided to write in Portuguese, even though it feels odd, to adhere strictly to the systems final instruction.”

--- a/style.css
+++ b/style.css
@@ -88,3 +88,96 @@ li {
         margin-left: 20px;
     }
 }
+
+.ai-quotes-content {
+    max-width: 900px;
+}
+
+.quote-rotator {
+    margin: 40px 0;
+}
+
+.quote-progress {
+    height: 4px;
+    width: 100%;
+    background-color: #E6E6E6;
+    overflow: hidden;
+}
+
+.quote-progress-bar {
+    height: 100%;
+    width: 0;
+    background-color: #0044AA;
+}
+
+.quote-card {
+    margin: 0;
+    padding: 32px;
+    border-left: 6px solid #0044AA;
+    background-color: #F8F8F8;
+}
+
+.quote-card blockquote {
+    margin: 0;
+    font-size: 32px;
+    line-height: 1.35;
+}
+
+.quote-card figcaption {
+    margin-top: 24px;
+    color: #555555;
+    font-size: 22px;
+}
+
+.quote-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 20px;
+}
+
+.quote-controls button {
+    border: 2px solid #0044AA;
+    background-color: white;
+    color: #0044AA;
+    cursor: pointer;
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 18px;
+    padding: 8px 14px;
+}
+
+.quote-controls button:hover,
+.quote-controls button:focus {
+    background-color: #0044AA;
+    color: white;
+}
+
+.quote-status {
+    color: #555555;
+    font-size: 16px;
+}
+
+@keyframes quote-progress {
+    from {
+        width: 0;
+    }
+    to {
+        width: 100%;
+    }
+}
+
+@media screen and (max-width: 650px) {
+    .quote-card {
+        padding: 22px;
+    }
+
+    .quote-card blockquote {
+        font-size: 26px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .quote-progress-bar {
+        animation: none !important;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, accessible rotating quotes page driven from a simple markdown source to showcase AI-related excerpts. 
- Offer a self-contained client-side rotator with sensible defaults and fallbacks when `ai-quotes.md` cannot be loaded. 
- Integrate the rotator into the site design with responsive styling and reduced-motion support.

### Description
- Add `ai-quotes.html` which implements a quote rotator UI, fetches `ai-quotes.md`, parses markdown entries, and cycles quotes with controls for previous/next/pause and an animated progress bar. 
- Add `ai-quotes.md` containing the initial set of quoted entries in blockquote-separated (`---`) markdown form used by the rotator. 
- Update `style.css` to include layout and visual styles for the rotator, progress animation via `@keyframes quote-progress`, responsive rules, and `prefers-reduced-motion` handling.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a7372fcc0832996aa46e2d93c6599)